### PR TITLE
add explicit QUnit.start to commonjs bundle test

### DIFF
--- a/test/commonjs-test.js
+++ b/test/commonjs-test.js
@@ -11,6 +11,8 @@ require( '../bower_components/qunit/qunit/qunit' );
 // CommonJS. The following tests check to see if the plugin
 // is on the jQuery namespace and nothing else.
 
+QUnit.start(); // starting qunit, or phantom js will have a problem
+
 QUnit.test( 'combobox should be defined on jQuery object', function ( assert ) {
 	assert.ok( $().combobox, 'combobox method is defined' );
 } );


### PR DESCRIPTION
Attempting to resolve travis fail on https://github.com/ExactTarget/fuelux/pull/1894
![image](https://cloud.githubusercontent.com/assets/347227/19943741/286d9884-a10f-11e6-98f6-e0c58cdce552.png)


 


